### PR TITLE
Fix package.json compile script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "private": true,
   "scripts": {
     "start": "http-server -p 12666",
-    "compile": "echo Typescript && tsc -v && webpack & echo Compile complete",
+    "compile": "echo Typescript && tsc -v && webpack && echo Compile complete",
     "build": "tsc -v && npm run sass && webpack && echo Build complete",
     "sass": "node-sass src/styles/styles.scss public/dist/styles.css",
     "sass-watch": "npm run sass -- -w",


### PR DESCRIPTION
Previously the compile script only had a single '&' between 2 of the
steps which meant it would complete too early, and then finish after
it looked like it was done. This is unexpected behaviour and needs to
be rectified.